### PR TITLE
Support working paths with whitespace

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
 const config = {
-  "subwaybuilderLocation": "C:\\Users\\piero\\AppData\\Local\\Programs\\Subway\ Builder\\", // appimage location image on linux or install directory on windows (something like C:\\Users\\[username]\\AppData\\Local\\Programs\\Subway\ Builder)
+  "subwaybuilderLocation": "C:\\Users\\Kai\\AppData\\Local\\Programs\\Subway\ Builder\\", // appimage location image on linux or install directory on windows (something like C:\\Users\\[username]\\AppData\\Local\\Programs\\Subway\ Builder)
   "places": [
     {
       "code": "YYZ",

--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
 const config = {
-  "subwaybuilderLocation": "C:\\Users\\Kai\\AppData\\Local\\Programs\\Subway\ Builder\\", // appimage location image on linux or install directory on windows (something like C:\\Users\\[username]\\AppData\\Local\\Programs\\Subway\ Builder)
+  "subwaybuilderLocation": "C:\\Users\\piero\\AppData\\Local\\Programs\\Subway\ Builder\\", // appimage location image on linux or install directory on windows (something like C:\\Users\\[username]\\AppData\\Local\\Programs\\Subway\ Builder)
   "places": [
     {
       "code": "YYZ",


### PR DESCRIPTION
I had the issue come up where because my github directory had a parent folder that contained whitespace, many of the commands in the patcher script would fail as they'd treat the whitespace as a separator for params. 

Did this with a utility function to parse out the file in a safer manner and then changed the string addition to just passing in params and then joining them (cursor wanted to do this and i *do* think it looks cleaner)

Only tested on Windows as that's the only version of Subway Builder I have, would welcome people on Linux / Mac to give it a shot