### PR TITLE
Various changes to make demand data functional

### DIFF
--- a/scripts/download_data.js
+++ b/scripts/download_data.js
@@ -121,7 +121,10 @@ const fetchPlacesData = async (bbox) => {
 (
   nwr["place"="neighbourhood"](${bbox.join(',')});
   nwr["place"="quarter"](${bbox.join(',')});
-  nwr["amenity"](${bbox.join(',')});
+  nwr["place"="suburb"](${bbox.join(',')});
+  nwr["place"="hamlet"](${bbox.join(',')});
+  nwr["place"="village"](${bbox.join(',')});
+  nwr["aeroway"="terminal"](${bbox.join(',')});
 );
 out geom;`
 

--- a/scripts/process_data.js
+++ b/scripts/process_data.js
@@ -98,6 +98,8 @@ const squareFeetPerJob = {
   stadium: 150,
 };
 
+let terminalTicker = 0;
+
 const processPlaceConnections = (place, rawBuildings, rawPlaces) => {
   let neighborhoods = {};
   let centersOfNeighborhoods = {};
@@ -105,7 +107,7 @@ const processPlaceConnections = (place, rawBuildings, rawPlaces) => {
 
   // finding areas of neighborhoods
   rawPlaces.forEach((place) => {
-    if (place.tags.place && (place.tags.place == 'quarter' || place.tags.place == 'neighbourhood')) {
+    if (place.tags.place && (place.tags.place == 'quarter' || place.tags.place == 'neighbourhood') || (place.tags.aeroway && place.tags.aeroway == 'terminal')) {
       neighborhoods[place.id] = place;
       if (place.type == 'node') {
         centersOfNeighborhoods[place.id] = [place.lon, place.lat];
@@ -151,7 +153,11 @@ const processPlaceConnections = (place, rawBuildings, rawPlaces) => {
           buildingCenter,
         };
       } else if (squareFeetPerJob[building.tags.building]) { // commercial/jobs
-        const approxJobs = Math.floor(buildingArea / squareFeetPerJob[building.tags.building]);
+        let approxJobs = Math.floor(buildingArea / squareFeetPerJob[building.tags.building]);
+
+        if(building.tags.aeroway && building.tags.aeroway == 'terminal'){
+          approxJobs *= 20;
+        }
 
         calculatedBuildings[building.id] = {
           ...building,
@@ -204,8 +210,17 @@ const processPlaceConnections = (place, rawBuildings, rawPlaces) => {
     finalVoronoiMetadata[place.placeID].percentOfTotalPopulation = place.totalPopulation / totalPopulation;
     finalVoronoiMetadata[place.placeID].percentOfTotalJobs = place.totalJobs / totalJobs;
 
+    let id = place.placeID;
+
+    if(neighborhoods[id] && neighborhoods[id].tags && neighborhoods[id].tags.aeroway && neighborhoods[id].tags.aeroway == 'terminal'){
+      id = "AIR_Terminal_" + terminalTicker;
+      terminalTicker++;
+      console.log("New terminal added:", id);
+    }
+
+
     finalNeighborhoods[place.placeID] = {
-      id: place.placeID,
+      id: id,
       location: centersOfNeighborhoods[place.placeID],
       jobs: place.totalJobs,
       residents: place.totalPopulation,
@@ -217,19 +232,30 @@ const processPlaceConnections = (place, rawBuildings, rawPlaces) => {
     // trust the process bro
     Object.values(finalVoronoiMetadata).forEach((innerPlace) => {
       //const connectionSizeBasedOnResidencePercent = outerPlace.percentOfTotalPopulation * innerPlace.totalJobs;
-      const connectionSizeBasedOnJobsPercent = innerPlace.percentOfTotalJobs * outerPlace.totalPopulation;
+      let connectionSizeBasedOnJobsPercent = innerPlace.percentOfTotalJobs * outerPlace.totalPopulation;
+      // prevent excessive no. of pops
+      if(connectionSizeBasedOnJobsPercent <= 50){
+        connectionSizeBasedOnJobsPercent = 0;
+      }
       const connectionDistance = turf.length(turf.lineString([
         centersOfNeighborhoods[outerPlace.placeID],
         centersOfNeighborhoods[innerPlace.placeID],
       ]), { units: 'meters' });
       const conncetionSeconds = connectionDistance * 0.12; // very scientific (hey, this is something i got from the subwaybuilder data)
-      neighborhoodConnections.push({
-        residenceId: outerPlace.placeID,
-        jobId: innerPlace.placeID,
-        size: Math.round(connectionSizeBasedOnJobsPercent), // SO MANY VIBES EVERYTHING IS JUST VIBES FUCK IT WE BALL
-        drivingDistance: Math.round(connectionDistance),
-        drivingSeconds: Math.round(conncetionSeconds),
-      })
+
+      // prevents excessively large pops, causing impossible-to-fit-in-metro groups
+      let totalSize = Math.round(connectionSizeBasedOnJobsPercent);
+      let splits = Math.ceil(totalSize / 400)
+
+      for(let i = 0; i < splits; i++){
+        neighborhoodConnections.push({
+          residenceId: outerPlace.placeID,
+          jobId: innerPlace.placeID,
+          size: Math.round(totalSize / splits),
+          drivingDistance: Math.round(connectionDistance),
+          drivingSeconds: Math.round(conncetionSeconds),
+        })
+      }
     });
   });
 
@@ -241,11 +267,18 @@ const processPlaceConnections = (place, rawBuildings, rawPlaces) => {
     .map((connection, i) => {
       const id = i.toString();
       finalNeighborhoods[connection.jobId].popIds.push(id);
+      finalNeighborhoods[connection.residenceId].popIds.push(id);
       return {
         ...connection,
         id,
       }
     });
+
+    // handle airport terminals
+  neighborhoodConnections.forEach((connection) =>{
+    connection.residenceId = finalNeighborhoods[connection.residenceId].id;
+    connection.jobId = finalNeighborhoods[connection.jobId].id;
+  });
 
   return {
     points: Object.values(finalNeighborhoods),

--- a/scripts/process_data.js
+++ b/scripts/process_data.js
@@ -98,6 +98,15 @@ const squareFeetPerJob = {
   stadium: 150,
 };
 
+// Terminals handled separately.
+const validPlaces = [
+  'quarter',
+  'neighbourhood',
+  'suburb',
+  'hamlet',
+  'village',
+];
+
 let terminalTicker = 0;
 
 const processPlaceConnections = (place, rawBuildings, rawPlaces) => {
@@ -107,7 +116,7 @@ const processPlaceConnections = (place, rawBuildings, rawPlaces) => {
 
   // finding areas of neighborhoods
   rawPlaces.forEach((place) => {
-    if (place.tags.place && (place.tags.place == 'quarter' || place.tags.place == 'neighbourhood') || (place.tags.aeroway && place.tags.aeroway == 'terminal')) {
+    if (place.tags.place && (validPlaces.includes(place.tags.place)) || (place.tags.aeroway && place.tags.aeroway == 'terminal')) {
       neighborhoods[place.id] = place;
       if (place.type == 'node') {
         centersOfNeighborhoods[place.id] = [place.lon, place.lat];


### PR DESCRIPTION
- Excessive pop sizes above 400 and below 50 are either split or culled
- Airport terminal demand now works (Most jank patch of this bunch as workarounds had to be made with airports not having a numerical id, be warned)
- Amenity is no longer queried for place (?)
- Suburbs, hamlets, villages, and terminals now added as pop locations

I think the demand data will inevitably have to be rewritten, as the current system creates way too many connections and is relatively inflexible, but in the meantime this makes the demand system actually playable as the previous version had pops so large it could not fit in subways and pops so small the connections would be 10x vanilla games and lag to hell and back